### PR TITLE
Fix wrong acid when auth ipv6; auth -o/logout without username (#6)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -222,16 +222,18 @@ func cmdAuth(c *cli.Context) error {
 		}
 
 		if len(settings.Ip) == 0 {
-			// Probe the ac_id parameter, required by wireless network
+			// Probe the ac_id parameter
 			// We do this only in Tsinghua, since it requires access to usereg.t.e.c/net.t.e.c
-			if retAcID, err := libauth.GetAcID(); err == nil {
+			// For v6, ac_id must be probed using different url
+			if retAcID, err := libauth.GetAcID(settings.V6); err == nil {
 				acID = retAcID
 			}
 		}
 	}
 	host := libauth.NewUrlProvider(domain, settings.Insecure)
 	if len(settings.Ip) == 0 && !settings.NoCheck {
-		online, _ := libauth.IsOnline(host, acID)
+		online, _, username := libauth.IsOnline(host, acID)
+		settings.Username = username
 		if online && !logout {
 			fmt.Println("Currently online!")
 			return nil
@@ -314,10 +316,10 @@ func cmdLogout(c *cli.Context) error {
 	} else {
 		loggo.ConfigureLoggers("<root>=INFO;libtunet=INFO")
 	}
-	err := requestUser()
-	if err != nil {
-		return err
-	}
+	//err := requestUser()
+	//if err != nil {
+	//	return err
+	//}
 	success, err := libtunet.LoginLogout(settings.Username, settings.Password, true)
 	if success {
 		fmt.Printf("Logout Successfully!\n")
@@ -346,7 +348,7 @@ func main() {
 	 auth-thu [options] login
 	 auth-thu [options] logout`,
 		Usage:    "Authenticating utility for Tsinghua",
-		Version:  "1.6",
+		Version:  "1.7",
 		HideHelp: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "username, u", Usage: "your TUNET account `name`"},
@@ -397,6 +399,7 @@ func main() {
 		Authors: []cli.Author{
 			{Name: "Yuxiang Zhang", Email: "yuxiang.zhang@tuna.tsinghua.edu.cn"},
 			{Name: "Nogeek", Email: "ritou11@gmail.com"},
+			{Name: "ZenithalHourlyRate", Email: "i@zenithal.me"},
 		},
 	}
 


### PR DESCRIPTION
* Fix wrong acid when auth ipv6

* Add feature: auto -o/logout without username

* Bump version to 1.7